### PR TITLE
Added COM component in Win32 app and CoCreateInstance from UWP Sidecar

### DIFF
--- a/BackgroundTask/BackgroundTaskCPP/Class.cpp
+++ b/BackgroundTask/BackgroundTaskCPP/Class.cpp
@@ -8,8 +8,11 @@
 
 using namespace winrt;
 using namespace Windows::Data::Xml::Dom;
+using namespace Windows::ApplicationModel::Background;
 using namespace Windows::UI::Notifications;
 
+inline constexpr CLSID CLSID_Win32BGTask = { 0x12345678, 0x1234, 0x1234, 0x12, 0x34, 0x12, 0x34, 0x56, 0x78, 0x90, 0xCD };
+inline constexpr CLSID IID_IBackgroundTask = { 2098451764, 64786, 17358, 140, 34, 234, 31, 241, 60, 6, 223 };
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
@@ -28,6 +31,8 @@ namespace winrt::BackgroundTaskCPP::implementation
     void Class::Run(const Windows::ApplicationModel::Background::IBackgroundTaskInstance& taskInstance)
     {
         createNotification();
+        com_ptr<winrt::Windows::ApplicationModel::Background::IBackgroundTask> task = nullptr;
+        HRESULT hr = CoCreateInstance(CLSID_Win32BGTask, nullptr, CLSCTX_LOCAL_SERVER, IID_IBackgroundTask, reinterpret_cast<void**>(task.put()));
     }
 
     void Class::createNotification()

--- a/BackgroundTask/Win32BackgroundTaskCPP/App.xaml.cpp
+++ b/BackgroundTask/Win32BackgroundTaskCPP/App.xaml.cpp
@@ -1,9 +1,12 @@
 #include "pch.h"
 #include "App.xaml.h"
 #include "MainWindow.xaml.h"
+#include "RegisterForCOM.h"
+#include "Win32BGClass.h"
 
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;
+using namespace winrt::Win32BackgroundTaskCPP;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -40,4 +43,36 @@ namespace winrt::Win32BackgroundTaskCPP::implementation
         window = make<MainWindow>();
         window.Activate();
     }
+}
+
+int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPWSTR lpCmdLine, _In_ int nShowCmd)
+{
+    winrt::init_apartment(winrt::apartment_type::single_threaded);
+    OutputDebugString(L"This is command line args: ");
+    OutputDebugString(lpCmdLine);
+
+    if (std::wcsncmp(lpCmdLine, RegisterForCom::RegisterForComToken, sizeof(RegisterForCom::RegisterForComToken)) == 0)
+    {
+        RegisterForCom comRegister;
+        comRegister.RegisterAndWait(__uuidof(Win32BGTask));
+        MSG msg;
+
+        while (-1 != GetMessage(&msg, NULL, 0, 0) &&
+            WM_QUIT != msg.message)
+        {
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
+    }
+    else
+    {
+        // put your fancy code somewhere here
+        ::winrt::Microsoft::UI::Xaml::Application::Start(
+            [](auto&&)
+            {
+                ::winrt::make<::winrt::Win32BackgroundTaskCPP::implementation::App>();
+            });
+    }
+
+    return 0;
 }

--- a/BackgroundTask/Win32BackgroundTaskCPP/MainWindow.xaml.cpp
+++ b/BackgroundTask/Win32BackgroundTaskCPP/MainWindow.xaml.cpp
@@ -6,6 +6,7 @@
 #include <winrt/Windows.ApplicationModel.Background.h>
 #include "winrt/Windows.UI.Notifications.h"
 #include "winrt/Windows.Data.Xml.Dom.h"
+#include "winrt/Windows.Storage.h"
 
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
@@ -13,6 +14,7 @@ using namespace Microsoft::UI::Xaml;
 using namespace Windows::Data::Xml::Dom;
 using namespace Windows::UI::Notifications;
 using namespace Windows::ApplicationModel::Background;
+using namespace Windows::Storage;
 using namespace std;
 
 // To learn more about WinUI, the WinUI project structure,
@@ -35,6 +37,21 @@ namespace winrt::Win32BackgroundTaskCPP::implementation
         myButton().Content(box_value(L"BG Task Registered, Check Notifications"));
         BackgroundTaskBuilder builder;
         builder.Name(L"SampleBackgroundTask");
+        //StorageFolder folder = co_await StorageFolder::GetFolderFromPathAsync(L"C:\\Users\\godlyalias\\Downloads\\");
+        //StorageLibraryChangeTracker tracker = folder.TryGetChangeTracker();
+        //if (tracker != nullptr)
+        //{
+        //    tracker.Enable();
+        //    StorageLibraryChangeTrackerTrigger trigger{ tracker };
+        //    auto backgroundTrigger = trigger.as<IBackgroundTrigger>();
+        //    builder.SetTrigger(backgroundTrigger);
+        //    builder.TaskEntryPoint(L"BackgroundTaskCPP.Class");
+        //    builder.Register();
+        //    createNotification();
+        //}
+
+        //MaintenanceTrigger trigger{ 15, false };
+
         ToastNotificationHistoryChangedTrigger trigger;
         auto backgroundTrigger = trigger.as<IBackgroundTrigger>();
         builder.SetTrigger(backgroundTrigger);

--- a/BackgroundTask/Win32BackgroundTaskCPP/Package.appxmanifest
+++ b/BackgroundTask/Win32BackgroundTaskCPP/Package.appxmanifest
@@ -5,17 +5,18 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="33e34c9b-37f4-4255-843f-b69f0e865d50"
+    Name="33e34c9b-37f4-4255-843f-b69f0e865d53"
     Publisher="CN=godlyalias"
     Version="1.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="33e34c9b-37f4-4255-843f-b69f0e865d50" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
   <Properties>
-    <DisplayName>Win32BackgroundTaskCPP</DisplayName>
+    <DisplayName>Win32BackgroundTaskCPP2</DisplayName>
     <PublisherDisplayName>godlyalias</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -34,8 +35,8 @@
       Executable="$targetnametoken$.exe"
       EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="Win32BackgroundTaskCPP"
-        Description="Win32BackgroundTaskCPP"
+        DisplayName="Win32BackgroundTaskCPP2"
+        Description="Win32BackgroundTaskCPP2"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png">
@@ -47,8 +48,18 @@
           <BackgroundTasks>
             <Task Type="systemEvent"/>
             <Task Type="timer"/>
+            <Task Type="general"/>
+            <uap:Task Type="mediaProcessing"/>
+            <Task Type="deviceUse"/>
           </BackgroundTasks>
         </Extension>
+			  <com:Extension Category="windows.comServer">
+				  <com:ComServer>
+					  <com:ExeServer Executable="Win32BackgroundTaskCPP.exe" Arguments="-RegisterForBGTaskServer" DisplayName="Win32BackgroundTaskCPP">
+						  <com:Class Id="12345678-1234-1234-1234-1234567890CD" DisplayName="Win32BackgroundTaskCPP Win32BGTask" />
+					  </com:ExeServer>
+				  </com:ComServer>
+			  </com:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/BackgroundTask/Win32BackgroundTaskCPP/RegisterForCOM.cpp
+++ b/BackgroundTask/Win32BackgroundTaskCPP/RegisterForCOM.cpp
@@ -1,0 +1,40 @@
+#include "pch.h"
+#include "RegisterForCom.h"
+#include "Win32BGClass.h"
+
+using namespace winrt;
+
+namespace winrt::Win32BackgroundTaskCPP
+{
+    RegisterForCom::~RegisterForCom()
+    {
+        if (ComRegistrationToken != 0)
+        {
+            CoRevokeClassObject(ComRegistrationToken);
+        }
+    }
+
+    hresult RegisterForCom::RegisterAndWait(guid classId)
+    {
+        hresult hr;
+        try
+        {
+            handle _taskFactoryCompletionEvent{ CreateEvent(nullptr, false, false, nullptr) };
+            com_ptr<IClassFactory> taskFactory = make<Win32BGTaskFactory>();
+
+            check_hresult(CoRegisterClassObject(classId,
+                taskFactory.get(),
+                CLSCTX_LOCAL_SERVER,
+                REGCLS_MULTIPLEUSE,
+                &ComRegistrationToken));
+
+            hr = S_OK;
+        }
+        catch (...)
+        {
+            hr = to_hresult();
+        }
+
+        return hr;
+    }
+};

--- a/BackgroundTask/Win32BackgroundTaskCPP/RegisterForCOM.h
+++ b/BackgroundTask/Win32BackgroundTaskCPP/RegisterForCOM.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "pch.h"
+
+namespace winrt::Win32BackgroundTaskCPP
+{
+	class RegisterForCom
+	{
+		DWORD ComRegistrationToken = 0;
+	public:
+		~RegisterForCom();
+		winrt::hresult RegisterAndWait(winrt::guid classId);
+		static constexpr wchar_t* RegisterForComToken = L"-RegisterForBGTaskServer";
+	};
+}

--- a/BackgroundTask/Win32BackgroundTaskCPP/Win32BGClass.cpp
+++ b/BackgroundTask/Win32BackgroundTaskCPP/Win32BGClass.cpp
@@ -1,0 +1,29 @@
+#include "pch.h"
+#include "Win32BGClass.h"
+#include "ToastNotificationCreator.h"
+
+using namespace winrt;
+namespace winrt
+{
+    using namespace winrt::Windows::ApplicationModel::Background;
+}
+
+namespace winrt::Win32BackgroundTaskCPP {
+
+    void __stdcall Win32BGTask::Run(_In_ IBackgroundTaskInstance taskInstance)
+    {
+        taskInstance.Canceled({ this, &Win32BGTask::OnCanceled });
+
+        TaskDeferral = taskInstance.GetDeferral();
+        ToastNotificationCreator(true);
+
+        TaskDeferral.Complete();
+    }
+
+    void __stdcall Win32BGTask::OnCanceled(_In_ IBackgroundTaskInstance /* taskInstance */, _In_ BackgroundTaskCancellationReason /* cancelReason */)
+    {
+        OutputDebugString(L"BG Task Cancelled");
+        IsCanceled = true;
+    }
+
+}

--- a/BackgroundTask/Win32BackgroundTaskCPP/Win32BGClass.h
+++ b/BackgroundTask/Win32BackgroundTaskCPP/Win32BGClass.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "pch.h"
+
+namespace winrt::Win32BackgroundTaskCPP
+{
+#define CLSID_Win32BGTask "12345678-1234-1234-1234-1234567890CD"
+
+
+	struct __declspec(uuid(CLSID_Win32BGTask))
+		Win32BGTask : implements<Win32BGTask, winrt::Windows::ApplicationModel::Background::IBackgroundTask>
+	{
+		volatile bool IsCanceled = false;
+		winrt::Windows::ApplicationModel::Background::BackgroundTaskDeferral TaskDeferral = nullptr;
+		void Run(_In_ winrt::Windows::ApplicationModel::Background::IBackgroundTaskInstance taskInstance);
+		void OnCanceled(_In_ winrt::Windows::ApplicationModel::Background::IBackgroundTaskInstance /* taskInstance */, _In_ winrt::Windows::ApplicationModel::Background::BackgroundTaskCancellationReason /* cancelReason */);
+
+	};
+
+	struct Win32BGTaskFactory : implements<Win32BGTaskFactory, IClassFactory>
+	{
+		HRESULT __stdcall CreateInstance(_In_opt_ IUnknown* aggregateInterface, _In_ REFIID interfaceId, _Outptr_ VOID** object) noexcept final
+		{
+			if (aggregateInterface != NULL) {
+				return CLASS_E_NOAGGREGATION;
+			}
+
+			return make<Win32BGTask>().as(interfaceId, object);
+		}
+
+		HRESULT __stdcall LockServer(BOOL lock) noexcept final
+		{
+			UNREFERENCED_PARAMETER(lock);
+			return S_OK;
+		}
+	};
+}
+

--- a/BackgroundTask/Win32BackgroundTaskCPP/Win32BackgroundTaskCPP.vcxproj
+++ b/BackgroundTask/Win32BackgroundTaskCPP/Win32BackgroundTaskCPP.vcxproj
@@ -86,12 +86,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;DISABLE_XAML_GENERATED_MAIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;DISABLE_XAML_GENERATED_MAIN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -114,6 +114,9 @@
     <ClInclude Include="MainWindow.xaml.h">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="RegisterForCOM.h" />
+    <ClInclude Include="ToastNotificationCreator.h" />
+    <ClInclude Include="Win32BGClass.h" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />
@@ -130,6 +133,9 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="RegisterForCOM.cpp" />
+    <ClCompile Include="ToastNotificationCreator.cpp" />
+    <ClCompile Include="Win32BGClass.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="MainWindow.idl">

--- a/BackgroundTask/Win32BackgroundTaskCPP/Win32BackgroundTaskCPP.vcxproj.filters
+++ b/BackgroundTask/Win32BackgroundTaskCPP/Win32BackgroundTaskCPP.vcxproj.filters
@@ -12,9 +12,15 @@
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="Win32BGClass.cpp" />
+    <ClCompile Include="ToastNotificationCreator.cpp" />
+    <ClCompile Include="RegisterForCOM.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="Win32BGClass.h" />
+    <ClInclude Include="ToastNotificationCreator.h" />
+    <ClInclude Include="RegisterForCOM.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Wide310x150Logo.scale-200.png">
@@ -55,5 +61,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
   </ItemGroup>
 </Project>

--- a/BackgroundTask/Win32BackgroundTaskCPP/pch.h
+++ b/BackgroundTask/Win32BackgroundTaskCPP/pch.h
@@ -22,4 +22,8 @@
 #include <winrt/Microsoft.UI.Xaml.Navigation.h>
 #include <winrt/Microsoft.UI.Xaml.Shapes.h>
 #include <winrt/Microsoft.UI.Dispatching.h>
+#include <winrt/Windows.ApplicationModel.Background.h>
 #include <wil/cppwinrt_helpers.h>
+#include "winrt/Windows.UI.Notifications.h"
+#include "winrt/Windows.Data.Xml.Dom.h"
+


### PR DESCRIPTION
- [Win32BackgroundTaskCPP](https://github.com/godlytalias/Win32_Samples/tree/main/BackgroundTask/Win32BackgroundTaskCPP) - Win32 Application that gets launched as UI application and registers Background Task for ToastNotificationHistoryChanged trigger

- [BackgroundTaskCPP](https://github.com/godlytalias/Win32_Samples/tree/main/BackgroundTask/BackgroundTaskCPP) - Windows Runtime Component that hosts the Background Task class, this gets executed in backgroundtaskhost process when a toast notification gets deleted (Toast notification gets created by UI app when background task gets registered)

- [Win32BGTask](https://github.com/godlytalias/Win32_Samples/blob/uwp_cocreate/BackgroundTask/Win32BackgroundTaskCPP/Win32BGClass.h) Background task COM Component that is supposed to be invoked from the UWP Sidecar Background process